### PR TITLE
Fixed missing part of colon in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ In your `build.gradle` file:
     }
     // optionally: ext.nextVersion = "major", "minor" (default), "patch" or e.g. "3.0.0-rc2"
     // optionally: ext.snapshotSuffix = "SNAPSHOT" (default) or a pattern, e.g. "<count>.g<sha>-SNAPSHOT"
-    apply plugin 'com.cinnober.gradle.semver-git'
+    apply plugin: 'com.cinnober.gradle.semver-git'
     
 Note: Use this method instead of the newer `plugins` method if you want to change `nextVersion` and `snapshotSuffix`.
 


### PR DESCRIPTION
If the colon is missing, the build fails with an error.