### PR TITLE
Update for remote tags which have 'refs/tags/' in front of the tag name

### DIFF
--- a/src/main/groovy/com/cinnober/gradle/semver_git/SemverGitPlugin.groovy
+++ b/src/main/groovy/com/cinnober/gradle/semver_git/SemverGitPlugin.groovy
@@ -57,7 +57,7 @@ class SemverGitPlugin implements Plugin<Project> {
     }
 
     def static Object[] parseVersion(String version) {
-        def pattern = /^([0-9]+)\.([0-9]+)\.([0-9]+)(-([a-zA-Z0-9.-]+))?$/
+        def pattern = /^(?:refs\/tags\/)?([0-9]+)\.([0-9]+)\.([0-9]+)(-([a-zA-Z0-9.-]+))?$/
         def matcher = version =~ pattern
         def arr = matcher.collect { it }[0]
         if (arr == null) {

--- a/src/main/groovy/com/cinnober/gradle/semver_git/SemverGitPlugin.groovy
+++ b/src/main/groovy/com/cinnober/gradle/semver_git/SemverGitPlugin.groovy
@@ -52,8 +52,7 @@ class SemverGitPlugin implements Plugin<Project> {
     }
 
     def static String checkVersion(String version) {
-        parseVersion(version);
-        return version;
+        return formatVersion(parseVersion(version));
     }
 
     def static Object[] parseVersion(String version) {

--- a/src/test/groovy/com/cinnober/gradle/semver_git/SemverGitPluginTest.groovy
+++ b/src/test/groovy/com/cinnober/gradle/semver_git/SemverGitPluginTest.groovy
@@ -43,7 +43,22 @@ class SemverGitPluginTest extends GroovyTestCase {
         testParseVersion("1.2.3-SNAPSHOT", [1,2,3,"SNAPSHOT"]);
     }
     void testParseVersion12_34_56_rc78() {
-        testParseVersion("12.34.56-rc78", [12,34,56,"rc78"]);
+        testParseVersion("refs/tags/12.34.56-rc78", [12,34,56,"rc78"]);
+    }
+    void testParseVersionRefsTags100() {
+        testParseVersion("refs/tags/1.0.0", [1,0,0,null]);
+    }
+    void testParseVersionRefsTags123() {
+        testParseVersion("refs/tags/1.2.3", [1,2,3,null]);
+    }
+    void testParseVersionRefsTags123beta() {
+        testParseVersion("refs/tags/1.2.3-beta", [1,2,3,"beta"]);
+    }
+    void testParseVersionRefsTags123snapshot() {
+        testParseVersion("refs/tags/1.2.3-SNAPSHOT", [1,2,3,"SNAPSHOT"]);
+    }
+    void testParseVersionRefsTags12_34_56_rc78() {
+        testParseVersion("refs/tags/12.34.56-rc78", [12,34,56,"rc78"]);
     }
     void testFailParseVersion_abc() {
         shouldFail({SemverGitPlugin.parseVersion("a.b.c")});

--- a/src/test/groovy/com/cinnober/gradle/semver_git/SemverGitPluginTest.groovy
+++ b/src/test/groovy/com/cinnober/gradle/semver_git/SemverGitPluginTest.groovy
@@ -43,7 +43,7 @@ class SemverGitPluginTest extends GroovyTestCase {
         testParseVersion("1.2.3-SNAPSHOT", [1,2,3,"SNAPSHOT"]);
     }
     void testParseVersion12_34_56_rc78() {
-        testParseVersion("refs/tags/12.34.56-rc78", [12,34,56,"rc78"]);
+        testParseVersion("12.34.56-rc78", [12,34,56,"rc78"]);
     }
     void testParseVersionRefsTags100() {
         testParseVersion("refs/tags/1.0.0", [1,0,0,null]);

--- a/src/test/groovy/com/cinnober/gradle/semver_git/SemverGitPluginTest.groovy
+++ b/src/test/groovy/com/cinnober/gradle/semver_git/SemverGitPluginTest.groovy
@@ -120,4 +120,7 @@ class SemverGitPluginTest extends GroovyTestCase {
         testNextVersion("1.0.0-SNAPSHOT", "1.0.0-beta", "major", "SNAPSHOT");
     }
 
+    void testCheckVersionShouldReturnWithoutRefsTags() {
+        assertEquals("1.0.0-beta", SemverGitPlugin.checkVersion("refs/tags/1.0.0-beta"))
+    }
 }


### PR DESCRIPTION
When using this in with continuous integration, the cloned git repo only had the tags from the remote repo, and when doing a git describe, the tags contain 'refs/tags/' in front of the tag name.
This change to the regex fixes this.