### PR TITLE
Add support for <dirty>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .gradle
 /build
 /buildSrc/build
+.idea
+*.iml
+out

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,8 @@ In your `build.gradle` file:
         }
     }
     // optionally: ext.nextVersion = "major", "minor" (default), "patch" or e.g. "3.0.0-rc2"
-    // optionally: ext.snapshotSuffix = "SNAPSHOT" (default) or a pattern, e.g. "<count>.g<sha>-SNAPSHOT"
+    // optionally: ext.snapshotSuffix = "SNAPSHOT" (default) or a pattern, e.g. "<count>.g<sha><dirty>-SNAPSHOT"
+    // optionally: ext.dirtyMarker = "-dirty" (default) replaces <dirty> in snapshotSuffix
     // optionally: ext.gitDescribeArgs = '--match *[0-9].[0-9]*.[0-9]*' (default) or other arguments for git describe.
     apply plugin: 'com.cinnober.gradle.semver-git'
     

--- a/src/main/groovy/com/cinnober/gradle/semver_git/SemverGitPlugin.groovy
+++ b/src/main/groovy/com/cinnober/gradle/semver_git/SemverGitPlugin.groovy
@@ -29,16 +29,20 @@ import org.gradle.api.Plugin
 
 class SemverGitPlugin implements Plugin<Project> {
 
-    def static String getGitVersion(String nextVersion, String snapshotSuffix, String gitArgs, File projectDir = null) {
+    def static String getGitVersion(String nextVersion, String snapshotSuffix, String dirtyMarker, String gitArgs, File projectDir = null) {
         def proc = ("git describe --exact-match " + gitArgs).execute(null, projectDir);
         proc.waitFor();
         if (proc.exitValue() == 0) {
             return checkVersion(proc.text.trim());
         }
-        proc =("git describe --abbrev=7 " + gitArgs).execute(null, projectDir);
+        proc = ("git describe --dirty --abbrev=7 " + gitArgs).execute(null, projectDir);
         proc.waitFor();
         if (proc.exitValue() == 0) {
             def describe = proc.text.trim()
+            def dirty =  describe.endsWith('-dirty')
+            if (dirty) {
+                describe = describe.substring(0, describe.length() - 6)
+            }
             def version = (describe =~ /-[0-9]+-g[0-9a-f]+$/).replaceFirst("")
             def suffixMatcher = (describe =~ /-([0-9]+)-g([0-9a-f]+)$/)
             def count = suffixMatcher[0][1];
@@ -46,6 +50,7 @@ class SemverGitPlugin implements Plugin<Project> {
             def suffix = snapshotSuffix;
             suffix = suffix.replaceAll("<count>", count);
             suffix = suffix.replaceAll("<sha>", sha);
+            suffix = suffix.replaceAll("<dirty>", dirty ? dirtyMarker : '');
             return getNextVersion(version, nextVersion, suffix);
         }
         return getNextVersion("0.0.0", nextVersion, "SNAPSHOT")
@@ -105,6 +110,7 @@ class SemverGitPlugin implements Plugin<Project> {
     void apply(Project project) {
         def nextVersion = "minor"
         def snapshotSuffix = "SNAPSHOT"
+        def dirtyMarker = "-dirty"
         def gitDescribeArgs = '--match *[0-9].[0-9]*.[0-9]*'
         if (project.ext.properties.containsKey("nextVersion")) {
             nextVersion = project.ext.nextVersion
@@ -115,7 +121,10 @@ class SemverGitPlugin implements Plugin<Project> {
         if (project.ext.properties.containsKey("gitDescribeArgs")) {
             gitDescribeArgs = project.ext.gitDescribeArgs
         }
-        project.version = getGitVersion(nextVersion, snapshotSuffix, gitDescribeArgs, project.projectDir)
+        if (project.ext.properties.containsKey("dirtyMarker")) {
+            dirtyMarker = project.ext.dirtyMarker
+        }
+        project.version = getGitVersion(nextVersion, snapshotSuffix, dirtyMarker, gitDescribeArgs, project.projectDir)
         project.task('showVersion') {
             group = 'Help'
             description = 'Show the project version'


### PR DESCRIPTION
This adds support for adding a `<dirty>` to `snapshotSuffix` (not included by default) and `ext.dirtyMarker` (defaults to `-dirty`) to set a marker to add if `git describe` says it's dirty