### PR TITLE
Add option to configure via semverGit {} block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,6 @@ group = 'com.cinnober.gradle'
 
 test {
   useJUnitPlatform()
-  retry {
-    maxRetries = 5
-  }
 }
 
 // -- Maven Central --

--- a/readme.md
+++ b/readme.md
@@ -9,16 +9,17 @@ Version numbers must follow [Semantic Versioning 2.0.0](http://semver.org/spec/v
 In your `build.gradle` file:
 
     plugins {
-        id "com.cinnober.gradle.semver-git" version "2.2.0" apply false
+        id "com.cinnober.gradle.semver-git" version "3.1.0"
     }
-    // optionally: ext.nextVersion = "major", "minor" (default), "patch" or e.g. "3.0.0-rc2"
-    // optionally: ext.snapshotSuffix = "SNAPSHOT" (default) or a pattern, e.g. "<count>.g<sha><dirty>-SNAPSHOT"
-    // optionally: ext.dirtyMarker = "-dirty" (default) replaces <dirty> in snapshotSuffix
-    // optionally: ext.gitDescribeArgs = '--match *[0-9].[0-9]*.[0-9]*' (default) or other arguments for git describe.
-    // optionally: ext.semverPrefix = 'v' if your tags are named like v3.0.0
-    apply plugin: 'com.cinnober.gradle.semver-git'
-    
-Note: Use `apply false` combined with a manual apply if you want to change `nextVersion` and `snapshotSuffix`.
+
+    semverGit {
+        // All of the following are optional:
+        nextVersion = "major", "minor" (default), "patch" or e.g. "3.0.0-rc2"
+        snapshotSuffix = "SNAPSHOT" (default) or a pattern, e.g. "<count>.g<sha><dirty>-SNAPSHOT"
+        dirtyMarker = "-dirty" (default) replaces <dirty> in snapshotSuffix
+        gitDescribeArgs = '--match *[0-9].[0-9]*.[0-9]*' (default) or other arguments for git describe.
+        prefix = 'v' if your tags are named like v3.0.0
+    }
 
 Then everything should just work. To create a release, create an
 annotated git tag, e.g.:
@@ -40,6 +41,29 @@ version `1.1.0-5.g5242341`, i.e. a non-snapshot pre-release.
 For example the snapshot suffix pattern is `<count>.g<sha>-SNAPSHOT`
 which will generate the version `1.1.0-5.g5242341-SNAPSHOT`, which is
 a unique snapshot version.
+
+
+### Legacy config ###
+
+Plugin versions 3.0.0 and earlier used a different config method,
+which required setting the configuration before applying the plugin:
+
+    plugins {
+        id "com.cinnober.gradle.semver-git" version "2.2.0" apply false
+    }
+    // optionally: ext.nextVersion = "major", "minor" (default), "patch" or e.g. "3.0.0-rc2"
+    // optionally: ext.snapshotSuffix = "SNAPSHOT" (default) or a pattern, e.g. "<count>.g<sha><dirty>-SNAPSHOT"
+    // optionally: ext.dirtyMarker = "-dirty" (default) replaces <dirty> in snapshotSuffix
+    // optionally: ext.gitDescribeArgs = '--match *[0-9].[0-9]*.[0-9]*' (default) or other arguments for git describe.
+    // optionally: ext.semverPrefix = 'v' if your tags are named like v3.0.0
+    apply plugin: 'com.cinnober.gradle.semver-git'
+
+Note: This configuration method requires `apply false` combined with a manual apply.
+
+Both legacy config and the newer `semverGit {}` config block may be
+used simultaneously. Any non-null setting defined using both methods
+will use the value from the `semverGit {}` block.
+
 
 ### Release ###
 

--- a/src/main/groovy/com/cinnober/gradle/semver_git/SemverGitPlugin.groovy
+++ b/src/main/groovy/com/cinnober/gradle/semver_git/SemverGitPlugin.groovy
@@ -26,6 +26,76 @@ package com.cinnober.gradle.semver_git
 
 import org.gradle.api.Project
 import org.gradle.api.Plugin
+import org.gradle.api.provider.Property
+
+interface SemverGitPluginExtension {
+    /**
+     * One of <code>"minor"</code> (default) or <code>"major"</code> to bump the respective SemVer part,
+     * or a literal value such as <code>"3.0.0-rc2"</code> to use as the next version.
+     */
+    Property<String> getNextVersion()
+
+    /**
+     * Pattern for the suffix to append when the current commit is not version tagged.
+     *
+     * <p>
+     * Example: <code>"&lt;count&gt;.g&lt;sha&gt;&lt;dirty&gt;-SNAPSHOT"</code>.
+     * </p>
+     *
+     * <p>
+     * Pattern may include the following placeholders:
+     * </p>
+     *
+     * <ul>
+     *   <li><code>&lt;count&gt;</code>: Number of commits (including this) since the last version tag.</li>
+     *   <li><code>&lt;sha&gt;</code>: Abbreviated ID of the current commit.</li>
+     *   <li><code>&lt;dirty&gt;</code>: The value of {@link #getDirtyMarker() dirtyMarker} if there are unstaged changes,
+     *   otherwise empty. Note that untracked files do not count.</li>
+     * </ul>
+     *
+     * <p>
+     * Default: <code>"SNAPSHOT"</code>
+     * </p>
+     */
+    Property<String> getSnapshotSuffix()
+
+    /**
+     * The value to substitute for <code>&lt;dirty&gt;</code> in {@link #getSnapshotSuffix() snapshotSuffix}
+     * if there are unstaged changes.
+     *
+     * <p>
+     * Note that this has no effect if {@link #getSnapshotSuffix() snapshotSuffix}
+     * does not include a <code>&lt;dirty&gt;</code> placeholder.
+     * </p>
+     *
+     * <p>
+     * Default: <code>"-dirty"</code>
+     * </p>
+     */
+    Property<String> getDirtyMarker()
+
+    /**
+     * Additional arguments for the <code>git describe</code> subprocess.
+     *
+     * <p>
+     * Default: <code>"--match *[0-9].[0-9]*.[0-9]*"</code>
+     * </p>
+     */
+    Property<String> getGitDescribeArgs()
+
+    /**
+     * A prefix that may be stripped from tag names to create a version number.
+     *
+     * <p>
+     * For example: if your tags are named like <code>v3.0.0</code>, set this to <code>"v"</code>.
+     * </p>
+     *
+     * <p>
+     * Default: null
+     * </p>
+     */
+    Property<String> getPrefix()
+}
 
 class SemverGitPlugin implements Plugin<Project> {
 
@@ -113,27 +183,36 @@ class SemverGitPlugin implements Plugin<Project> {
     }
 
     void apply(Project project) {
-        def nextVersion = "minor"
-        def snapshotSuffix = "SNAPSHOT"
-        def dirtyMarker = "-dirty"
-        def gitDescribeArgs = '--match *[0-9].[0-9]*.[0-9]*'
-        String semverPrefix = null
+        def extension = project.extensions.create("semverGit", SemverGitPluginExtension)
+        extension.nextVersion.convention("minor")
+        extension.snapshotSuffix.convention("SNAPSHOT")
+        extension.dirtyMarker.convention("-dirty")
+        extension.gitDescribeArgs.convention('--match *[0-9].[0-9]*.[0-9]*')
+        extension.prefix.convention(null)
+
         if (project.ext.properties.containsKey("nextVersion")) {
-            nextVersion = project.ext.nextVersion
+            extension.nextVersion.set(project.ext.nextVersion)
         }
         if (project.ext.properties.containsKey("snapshotSuffix")) {
-            snapshotSuffix = project.ext.snapshotSuffix
+            extension.snapshotSuffix.set(project.ext.snapshotSuffix)
         }
         if (project.ext.properties.containsKey("gitDescribeArgs")) {
-            gitDescribeArgs = project.ext.gitDescribeArgs
+            extension.gitDescribeArgs.set(project.ext.gitDescribeArgs)
         }
         if (project.ext.properties.containsKey("dirtyMarker")) {
-            dirtyMarker = project.ext.dirtyMarker
+            extension.dirtyMarker.set(project.ext.dirtyMarker)
         }
         if (project.ext.properties.containsKey("semverPrefix")) {
-            semverPrefix = project.ext.semverPrefix
+            extension.prefix.set(project.ext.semverPrefix)
         }
-        project.version = getGitVersion(nextVersion, snapshotSuffix, dirtyMarker, gitDescribeArgs, semverPrefix, project.projectDir)
+        project.version = getGitVersion(
+          extension.nextVersion.getOrNull(),
+          extension.snapshotSuffix.getOrNull(),
+          extension.dirtyMarker.getOrNull(),
+          extension.gitDescribeArgs.getOrNull(),
+          extension.prefix.getOrNull(),
+          project.projectDir
+        )
         project.tasks.register('showVersion') {
             group = 'Help'
             description = 'Show the project version'

--- a/src/main/groovy/com/cinnober/gradle/semver_git/SemverGitPlugin.groovy
+++ b/src/main/groovy/com/cinnober/gradle/semver_git/SemverGitPlugin.groovy
@@ -98,12 +98,12 @@ interface SemverGitPluginExtension {
 }
 
 class DeferredVersion {
-    private final Project project;
+    private final File projectDir;
     private final SemverGitPluginExtension extension;
     private String version = null;
 
-    DeferredVersion(Project project, SemverGitPluginExtension extension) {
-        this.project = project;
+    DeferredVersion(File projectDir, SemverGitPluginExtension extension) {
+        this.projectDir = projectDir;
         this.extension = extension;
     }
 
@@ -115,7 +115,7 @@ class DeferredVersion {
               this.extension.dirtyMarker.getOrNull(),
               this.extension.gitDescribeArgs.getOrNull(),
               this.extension.prefix.getOrNull(),
-              this.project.projectDir
+              this.projectDir
             )
         }
         return version;
@@ -238,7 +238,7 @@ class SemverGitPlugin implements Plugin<Project> {
             extension.prefix.set(project.ext.semverPrefix)
         }
 
-        project.version = new DeferredVersion(project, extension)
+        project.version = new DeferredVersion(project.projectDir, extension)
 
         project.tasks.register('showVersion') {
             group = 'Help'

--- a/src/test/groovy/com/cinnober/gradle/semver_git/SemverGitPluginFunctionalTest.groovy
+++ b/src/test/groovy/com/cinnober/gradle/semver_git/SemverGitPluginFunctionalTest.groovy
@@ -90,6 +90,10 @@ class SemverGitPluginFunctionalTest extends Specification {
 
     def init() {
         git("init")
+
+        // Disable GPG signing in the test directory, otherwise user might be prompted for
+        // manual intervention if they have this config set to true
+        return git("config commit.gpgSign false")
     }
 
     def commit() {

--- a/src/test/groovy/com/cinnober/gradle/semver_git/SemverGitPluginFunctionalTest.groovy
+++ b/src/test/groovy/com/cinnober/gradle/semver_git/SemverGitPluginFunctionalTest.groovy
@@ -2,7 +2,6 @@ package com.cinnober.gradle.semver_git
 
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
-import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.TempDir
@@ -10,7 +9,6 @@ import spock.lang.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
 
-@Ignore
 class SemverGitPluginFunctionalTest extends Specification {
     @Shared
     Boolean slowIo = false
@@ -85,11 +83,13 @@ class SemverGitPluginFunctionalTest extends Specification {
     }
 
     def git(String argument) {
-        return ("git " + argument).execute(null, projectDir)
+        def proc = ("git " + argument).execute(null, projectDir)
+        proc.waitFor()
+        return proc
     }
 
     def init() {
-        return git("init")
+        git("init")
     }
 
     def commit() {

--- a/src/test/groovy/com/cinnober/gradle/semver_git/SemverGitPluginFunctionalTest.groovy
+++ b/src/test/groovy/com/cinnober/gradle/semver_git/SemverGitPluginFunctionalTest.groovy
@@ -59,7 +59,7 @@ class SemverGitPluginFunctionalTest extends Specification {
 
     def "Prefixed tag"() {
         when:
-        setupPluginWithClasspath('v')
+        setupPluginWithClasspath(prefix: 'v')
         init()
         commit()
         tag("v1.0.0")
@@ -71,7 +71,7 @@ class SemverGitPluginFunctionalTest extends Specification {
 
     def "Prefixed tag with commit"() {
         when:
-        setupPluginWithClasspath('v')
+        setupPluginWithClasspath(prefix: 'v')
         init()
         commit()
         tag("v1.0.0")
@@ -82,6 +82,112 @@ class SemverGitPluginFunctionalTest extends Specification {
         result.getOutput().contains("Version: 1.1.0-SNAPSHOT")
     }
 
+    def "Dirty tag with default config"() {
+        when:
+        setupPluginWithClasspath()
+        init()
+        commit()
+        tag("1.0.0")
+        touchBuildFile()
+        BuildResult result = gradleBuild("showVersion")
+
+        then:
+        result.getOutput().contains("Version: 1.0.0")
+    }
+
+    def "Dirty tag with snapshotSuffix with <dirty>"() {
+        when:
+        setupPluginWithClasspath(snapshotSuffix: "SNAPSHOT<dirty>")
+        init()
+        commit()
+        tag("1.0.0")
+        touchBuildFile()
+        BuildResult result = gradleBuild("showVersion")
+
+        then:
+        result.getOutput().contains("Version: 1.0.0")
+    }
+
+    def "Dirty untagged commit with default config"() {
+        when:
+        setupPluginWithClasspath()
+        init()
+        commit()
+        tag("1.0.0")
+        commit()
+        touchBuildFile()
+        BuildResult result = gradleBuild("showVersion")
+
+        then:
+        result.getOutput().contains("Version: 1.1.0-SNAPSHOT")
+    }
+
+    def "Dirty untagged commit with snapshotSuffix with <dirty>"() {
+        when:
+        setupPluginWithClasspath(snapshotSuffix: "SNAPSHOT<dirty>")
+        init()
+        commit()
+        tag("1.0.0")
+        commit()
+        touchBuildFile()
+        BuildResult result = gradleBuild("showVersion")
+
+        then:
+        result.getOutput().contains("Version: 1.1.0-SNAPSHOT-dirty")
+    }
+
+    def "Custom nextVersion"() {
+        when:
+        setupPluginWithClasspath(nextVersion: "major")
+        init()
+        commit()
+        tag("1.0.0")
+        commit()
+        BuildResult result = gradleBuild("showVersion")
+
+        then:
+        result.getOutput().contains("Version: 2.0.0-SNAPSHOT")
+    }
+
+    def "Custom snapshotSuffix"() {
+        when:
+        setupPluginWithClasspath(snapshotSuffix: "volatile")
+        init()
+        commit()
+        tag("1.0.0")
+        commit()
+        BuildResult result = gradleBuild("showVersion")
+
+        then:
+        result.getOutput().contains("Version: 1.1.0-volatile")
+    }
+
+    def "Custom dirtyMarker"() {
+        when:
+        setupPluginWithClasspath(snapshotSuffix: "SNAPSHOT<dirty>", dirtyMarker: "_MODIFIED")
+        init()
+        commit()
+        tag("1.0.0")
+        commit()
+        touchBuildFile()
+        BuildResult result = gradleBuild("showVersion")
+
+        then:
+        result.getOutput().contains("Version: 1.1.0-SNAPSHOT_MODIFIED")
+    }
+
+    def "Custom gitDescribeArgs"() {
+        when:
+        setupPluginWithClasspath(gitDescribeArgs: "--long")
+        init()
+        String shortCommit = commit()
+        tag("1.0.0")
+        BuildResult result = gradleBuild("showVersion")
+
+        then:
+        result.getOutput().contains("Version: 1.0.0-0-g${shortCommit}")
+    }
+
     def git(String argument) {
         def proc = ("git " + argument).execute(null, projectDir)
         proc.waitFor()
@@ -90,6 +196,7 @@ class SemverGitPluginFunctionalTest extends Specification {
 
     def init() {
         git("init")
+        git("add .")
 
         // Disable GPG signing in the test directory, otherwise user might be prompted for
         // manual intervention if they have this config set to true
@@ -97,29 +204,30 @@ class SemverGitPluginFunctionalTest extends Specification {
     }
 
     def commit() {
-        return git("commit --allow-empty -m empty")
+        git("commit --allow-empty -m empty")
+        return git("rev-parse --short HEAD").text.trim()
     }
 
     def tag(String name) {
         return git("tag -a $name -m tag")
     }
 
-    def setupPluginWithClasspath(
-            String prefix = null
-    ) {
-        build.write """
+    def touchBuildFile() {
+        build << "\n// foo\n"
+    }
+
+    def setupPluginWithClasspath(Map args = [:]) {
+        build << """
 plugins {
     id "com.cinnober.gradle.semver-git" apply false
 }
-// optionally: ext.nextVersion = "major", "minor" (default), "patch" or e.g. "3.0.0-rc2"
-// optionally: ext.snapshotSuffix = "SNAPSHOT" (default) or a pattern, e.g. "<count>.g<sha><dirty>-SNAPSHOT"
-// optionally: ext.dirtyMarker = "-dirty" (default) replaces <dirty> in snapshotSuffix
-// optionally: ext.gitDescribeArgs = '--match *[0-9].[0-9]*.[0-9]*' (default) or other arguments for git describe.
-"""
-        if (prefix) {
-            build << "ext.semverPrefix = '$prefix'"
-        }
-        build << """
+
+${args.nextVersion != null ? "ext.nextVersion = '${args.nextVersion}'" : ""}
+${args.snapshotSuffix != null ? "ext.snapshotSuffix = '${args.snapshotSuffix}'" : ""}
+${args.dirtyMarker != null ? "ext.dirtyMarker = '${args.dirtyMarker}'" : ""}
+${args.gitDescribeArgs != null ? "ext.gitDescribeArgs = '${args.gitDescribeArgs}'" : ""}
+${args.prefix != null ? "ext.semverPrefix = '${args.prefix}'" : ""}
+
 apply plugin: 'com.cinnober.gradle.semver-git'
 """
     }


### PR DESCRIPTION
This allows the plugin to be applied with the new `plugins {}` DSL.

Fixes #3. Alleviates #14. Fixes #26.